### PR TITLE
Update outdated attribute for the company entity

### DIFF
--- a/src/Teamleader/Entities/Company.php
+++ b/src/Teamleader/Entities/Company.php
@@ -19,7 +19,7 @@ class Company extends Model {
         'name',
         'business_type_id',
         'vat_number',
-        'local_business_number',
+        'national_identification_number',
         'emails',
         'telephones',
         'website',


### PR DESCRIPTION
The property local_business_number was renamed to national_identification_number on the following endpoints on 2019-01-24:
companies.info
companies.list
companies.add
companies.update
invoices.info
creditNotes.info

This information can be found on https://developer.teamleader.eu 