### PR TITLE
Update php version to a supported and secure version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "guzzlehttp/guzzle": "^6.0"
     },
     "autoload": {


### PR DESCRIPTION
PHP 5.5 - 7.0 is outdated and unsupported. 
I would suggest to have a minimum requirement of PHP 7.1

http://php.net/eol.php