### PR TITLE
Trying to get accesstoken throws errors cause cache doesn't exist

### DIFF
--- a/src/Teamleader/Connection.php
+++ b/src/Teamleader/Connection.php
@@ -92,13 +92,13 @@ class Connection
      */
     public function getAccessToken()
     {
-        $accesstoken = $this->cache->get('accessToken');
+        $accesstoken = $this->cacheHandler->get('accessToken');
         if($accesstoken)
         {
             return $accesstoken;
         }
 
-        $refreshToken = $this->cache->get('refreshToken');
+        $refreshToken = $this->cacheHandler->get('refreshToken');
         if($refreshToken) {
             $this->acquireRefreshToken();
 


### PR DESCRIPTION
When updating the package retrieving accessToken would always throw an error since the $this->cache didn't exist in the connection class. I don't know if this was intentional or a typo but I think it should be $this->cacheHandler, if not you can ignore my pull request :) 