### PR TITLE
Adjust teamleader urls to focus.teamleader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Teamleader API v2 PHP SDK
 
-This is a PHP wrapper for the Teamleader API v2. Documentation of the API can be found here: [https://developer.teamleader.eu/](https://developer.teamleader.eu/).
+This is a PHP wrapper for the Teamleader API v2. Documentation of the API can be found here: [https://developer.focus.teamleader.eu/](https://developer.focus.teamleader.eu/).
 Please note that the Teamleader API v2 is not complete and some Entities and Actions are missing.
 
 Currently we only support a few entities and per entity only a few actions:
@@ -32,7 +32,7 @@ Currently we only support a few entities and per entity only a few actions:
 25. Custom fields (get)
 26. Quotations (get, getById, download, file)
 
-Teamleader API v2 works with OAuth2. This means your application needs to be registered on the [Teamleader Marketplace](https://marketplace.teamleader.eu/nl/nl/ontwikkel/integraties) (you can keep them private though).
+Teamleader API v2 works with OAuth2. This means your application needs to be registered on the [Teamleader Marketplace](https://marketplace.focus.teamleader.eu/nl/nl/ontwikkel/integraties) (you can keep them private though).
 
 Please contact me at jan@jannesmannes.nl if you have any feedback or questions.
 

--- a/Tests/Teamleader/Actions/AddCompanyTest.php
+++ b/Tests/Teamleader/Actions/AddCompanyTest.php
@@ -35,7 +35,7 @@ class AddCompanyTest extends \PHPUnit\Framework\TestCase
             ],
         'added_at' => '2019-02-15T07:27:54+00:00',
         'updated_at' => '2019-02-15T07:27:54+00:00',
-        'web_url' => 'https://app.teamleader.eu/company_detail.php?id=e9fb81ca-983f-0bca-bc71-0963618dbae8',
+        'web_url' => 'https://focus.teamleader.eu/company_detail.php?id=e9fb81ca-983f-0bca-bc71-0963618dbae8',
         'primary_address' =>
             [
                 'line_1' => 'Dok Noord 3A/101',

--- a/Tests/Teamleader/Actions/AddContactTest.php
+++ b/Tests/Teamleader/Actions/AddContactTest.php
@@ -36,7 +36,7 @@ class AddContactTest extends \PHPUnit\Framework\TestCase
             ],
         'added_at' => '2019-02-15T07:27:54+00:00',
         'updated_at' => '2019-02-15T07:27:54+00:00',
-        'web_url' => 'https://app.teamleader.eu/contact_detail.php?id=a9601b72-fcf7-07d0-8d79-041c91cf65c1',
+        'web_url' => 'https://focus.teamleader.eu/contact_detail.php?id=a9601b72-fcf7-07d0-8d79-041c91cf65c1',
         'primary_address' =>
             [
                 'line_1' => NULL,

--- a/Tests/Teamleader/Entities/CompanyTest.php
+++ b/Tests/Teamleader/Entities/CompanyTest.php
@@ -46,7 +46,7 @@ class CompanyTest extends \PHPUnit\Framework\TestCase
                                         ],
                                     'added_at' => '2019-02-15T07:27:54+00:00',
                                     'updated_at' => '2019-02-15T07:27:54+00:00',
-                                    'web_url' => 'https://app.teamleader.eu/company_detail.php?id=e9fb81ca-983f-0bca-bc71-0963618dbae8',
+                                    'web_url' => 'https://focus.teamleader.eu/company_detail.php?id=e9fb81ca-983f-0bca-bc71-0963618dbae8',
                                     'primary_address' =>
                                         [
                                             'line_1' => 'Dok Noord 3A/101',

--- a/Tests/Teamleader/Entities/ContactTest.php
+++ b/Tests/Teamleader/Entities/ContactTest.php
@@ -45,7 +45,7 @@ class ContactTest extends \PHPUnit\Framework\TestCase
                                     ],
                                 'added_at' => '2019-02-15T07:27:54+00:00',
                                 'updated_at' => '2019-02-15T07:27:54+00:00',
-                                'web_url' => 'https://app.teamleader.eu/contact_detail.php?id=a9601b72-fcf7-07d0-8d79-041c91cf65c1',
+                                'web_url' => 'https://focus.teamleader.eu/contact_detail.php?id=a9601b72-fcf7-07d0-8d79-041c91cf65c1',
                                 'primary_address' =>
                                     [
                                         'line_1' => NULL,

--- a/Tests/Teamleader/Entities/DealTest.php
+++ b/Tests/Teamleader/Entities/DealTest.php
@@ -72,7 +72,7 @@ class DealTest extends \PHPUnit\Framework\TestCase
                             ],
                             'created_at' => '2017-05-09T11:25:11+00:00',
                             'updated_at' => '2017-05-09T11:30:58+00:00',
-                            'web_url' => 'https://app.teamleader.eu/sale_detail.php?id=f6871b06-6513-4750-b5e6-ff3503b5a029',
+                            'web_url' => 'https://focus.teamleader.eu/sale_detail.php?id=f6871b06-6513-4750-b5e6-ff3503b5a029',
                             'custom_fields' => [
                                 0 => [
                                     'definition' => [

--- a/examples/add-company.php
+++ b/examples/add-company.php
@@ -42,7 +42,7 @@ $companyData = [
         ],
     'added_at' => '2019-02-15T07:27:54+00:00',
     'updated_at' => '2019-02-15T07:27:54+00:00',
-    'web_url' => 'https://app.teamleader.eu/company_detail.php?id=e9fb81ca-983f-0bca-bc71-0963618dbae8',
+    'web_url' => 'https://focus.teamleader.eu/company_detail.php?id=e9fb81ca-983f-0bca-bc71-0963618dbae8',
     'primary_address' =>
         [
             'line_1' => 'Dok Noord 3A/101',

--- a/src/Teamleader/Connection.php
+++ b/src/Teamleader/Connection.php
@@ -33,17 +33,17 @@ class Connection
     /**
      * @var string
      */
-    private $apiUrl = 'https://api.teamleader.eu';
+    private $apiUrl = 'https://api.focus.teamleader.eu';
 
     /**
      * @var string
      */
-    private $authUrl = 'https://app.teamleader.eu/oauth2/authorize';
+    private $authUrl = 'https://focus.teamleader.eu/oauth2/authorize';
 
     /**
      * @var string
      */
-    private $tokenUrl = 'https://app.teamleader.eu/oauth2/access_token';
+    private $tokenUrl = 'https://focus.teamleader.eu/oauth2/access_token';
 
     /**
      * @var string


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.