### PR TITLE
Fix responsible_user_id field

### DIFF
--- a/src/Teamleader/Entities/CRM/Company.php
+++ b/src/Teamleader/Entities/CRM/Company.php
@@ -32,7 +32,7 @@ class Company extends Model
         'preferred_currency',
         'payment_term', // { "type": "" }
         'invoicing_preferences', // { "electronic_invoicing_address": "" }
-        'responsible_user', // { "type": "", "id" : "" }
+        'responsible_user_id', // { "type": "", "id" : "" }
         'remarks',
         'added_at',
         'updated_at',


### PR DESCRIPTION
The field responsible_user does not exist in the Teamleader api. The real name of the field is responsible_user_id. At the moment it is not possible to set an account manager to a company in TL, after this fix it is.