### PR TITLE
Fix jsonSerialize deprecation notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "autoload": {

--- a/src/Teamleader/Model.php
+++ b/src/Teamleader/Model.php
@@ -2,15 +2,15 @@
 
 namespace Teamleader;
 
+use JsonSerializable;
 use Teamleader\Entities\CRM\Company;
 use Teamleader\Entities\CRM\Contact;
 use Teamleader\Entities\Deals\Deal;
 use Teamleader\Entities\General\User;
 use Teamleader\Entities\General\WorkType;
 use Teamleader\Entities\Invoicing\Invoice;
-use JsonSerializable;
-use Teamleader\Entities\Products\ProductCategory;
 use Teamleader\Entities\Products\Product;
+use Teamleader\Entities\Products\ProductCategory;
 use Teamleader\Entities\Projects\Milestone;
 use Teamleader\Entities\Projects\Project;
 use Teamleader\Entities\Tasks\Task;
@@ -456,7 +456,7 @@ abstract class Model implements JsonSerializable
         return (isset($this->attributes[$name]) && !is_null($this->attributes[$name]));
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         if (!defined('static::TYPE')) {
             return $this->getArrayWithNestedObjects();

--- a/src/Teamleader/Model.php
+++ b/src/Teamleader/Model.php
@@ -2,15 +2,15 @@
 
 namespace Teamleader;
 
-use JsonSerializable;
 use Teamleader\Entities\CRM\Company;
 use Teamleader\Entities\CRM\Contact;
 use Teamleader\Entities\Deals\Deal;
 use Teamleader\Entities\General\User;
 use Teamleader\Entities\General\WorkType;
 use Teamleader\Entities\Invoicing\Invoice;
-use Teamleader\Entities\Products\Product;
+use JsonSerializable;
 use Teamleader\Entities\Products\ProductCategory;
+use Teamleader\Entities\Products\Product;
 use Teamleader\Entities\Projects\Milestone;
 use Teamleader\Entities\Projects\Project;
 use Teamleader\Entities\Tasks\Task;


### PR DESCRIPTION
Model::jsonSerialize() is not compatible with JsonSerializable resulting in a deprecation warning on php 8.x

Adding a JsonSerializable(): **mixed** fixes the warning.